### PR TITLE
Error values as enum

### DIFF
--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -1,3 +1,5 @@
+use crate::Error;
+
 #[derive(Debug, PartialEq)]
 #[repr(u8)]
 pub enum Condition {
@@ -19,7 +21,7 @@ pub enum Condition {
 }
 
 impl TryFrom<u8> for Condition {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
@@ -38,7 +40,7 @@ impl TryFrom<u8> for Condition {
             12 => Ok(Condition::GT),
             13 => Ok(Condition::LE),
             14 => Ok(Condition::None),
-            _ => Err("Invalid condition"),
+            _ => Err(Error::InvalidCondition),
         }
     }
 }

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -56,6 +56,9 @@ mod tests {
             assert_eq!(cond as u8, n)
         }
 
-        assert_eq!(15.try_into(), Err::<Condition, &'static str>("Invalid condition"))
+        assert_eq!(
+            15.try_into(),
+            Err::<Condition, &'static str>("Invalid condition")
+        )
     }
 }

--- a/src/instructons.rs
+++ b/src/instructons.rs
@@ -338,14 +338,14 @@ mod test {
             width: InstructionWidth::Bit32,
             operation: Operation::NOP,
         };
-        assert_eq!(instruction_32.is_32bit(), true);
-        assert_eq!(instruction_32.is_16bit(), false);
+        assert!(instruction_32.is_32bit());
+        assert!(!instruction_32.is_16bit());
 
         let instruction_16 = Instruction {
             width: InstructionWidth::Bit16,
             operation: Operation::NOP,
         };
-        assert_eq!(instruction_16.is_32bit(), false);
-        assert_eq!(instruction_16.is_16bit(), true);
+        assert!(!instruction_16.is_32bit());
+        assert!(instruction_16.is_16bit());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use instructons::*;
 use registers::*;
 use tracing::debug;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Input not long enough for a instruction.
     InsufficientInput,
@@ -38,7 +38,7 @@ pub enum Error {
     /// Trying to access an invalid register.
     InvalidRegister,
     /// Invalid condition code used.
-    InvalidCondition
+    InvalidCondition,
 }
 
 /// This function parses a input byte slice into one instruction.

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,3 +1,5 @@
+use crate::Error;
+
 /// Normal register type.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[repr(u8)]
@@ -21,7 +23,7 @@ pub enum Register {
 }
 
 impl TryFrom<u8> for Register {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
@@ -41,7 +43,7 @@ impl TryFrom<u8> for Register {
             13 => Ok(Register::SP),
             14 => Ok(Register::LR),
             15 => Ok(Register::PC),
-            _ => Err("Not a valid register."),
+            _ => Err(Error::InvalidRegister),
         }
     }
 }
@@ -64,7 +66,7 @@ pub enum SpecialRegister {
 }
 
 impl TryFrom<u8> for SpecialRegister {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
@@ -79,7 +81,7 @@ impl TryFrom<u8> for SpecialRegister {
             9 => Ok(SpecialRegister::PSP),
             16 => Ok(SpecialRegister::PRIMASK),
             20 => Ok(SpecialRegister::CONTROL),
-            _ => Err("not a valid register"),
+            _ => Err(Error::InvalidRegister),
         }
     }
 }
@@ -119,7 +121,7 @@ mod tests {
         assert_eq!(15.try_into(), Ok(Register::PC));
         assert_eq!(
             16.try_into(),
-            Err::<Register, &str>("Not a valid register.")
+            Err::<Register, Error>(Error::InvalidRegister)
         )
     }
 


### PR DESCRIPTION
# Error values as enum

This PR aims to remove all 'static lifetime identifiers from the crate and also make the edge cases more transparent to the end user. This is achieved by moving all of the `&'static str` errors to be parts of an enum [`Error`](./src/lib.rs) that enumerates the
error cases for the crate thus removing the need for `&'static str`.




closes #1